### PR TITLE
Fix build errors #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postcss-load-config": "^2.1.0",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "~6.1.1",
     "rollup-plugin-terser": "^5.1.2",
     "svelte": "^3.0.0",
     "svelte-preprocess": "^3.7.4",


### PR DESCRIPTION
Update rollup-plugin-svelte  to fix compile error when building bundle.js